### PR TITLE
Add JSON Server Example

### DIFF
--- a/eg/README.md
+++ b/eg/README.md
@@ -1,0 +1,15 @@
+# Examples
+
+These directories include example snippets for how to do various things with
+RiveScript-Go.
+
+## RiveScript Example
+
+* [brain](brain/) - The standard default RiveScript brain (`.rive` files) that
+  implements an Eliza-like bot with added triggers to demonstrate other
+  features of RiveScript.
+
+## Client Examples
+
+* [json-server](json-server/) - A minimal Go web server that makes a RiveScript
+  bot available at a JSON POST endpoint.

--- a/eg/json-server/.gitignore
+++ b/eg/json-server/.gitignore
@@ -1,0 +1,1 @@
+json-server

--- a/eg/json-server/README.md
+++ b/eg/json-server/README.md
@@ -1,0 +1,171 @@
+# JSON Server
+
+This example demonstrates embedding RiveScript in a Go web app, accessible via
+a JSON endpoint.
+
+## Run the Example
+
+Run one of these in a terminal:
+
+```bash
+# Quick run
+go run main.go
+
+# Build and run
+go build -o json-server main.go
+./json-server [options] [path/to/brain]
+```
+
+Then you can visit the web server at <http://localhost:8000/> where you can
+find an example `curl` command to run from a terminal, and an in-browser demo
+that makes an ajax request to the endpoint.
+
+From another terminal, you can use `curl` to test a JSON endpoint for the
+chatbot. Or, you can use your favorite REST client.
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"username": "kirsle", "message": "Hello, robot"}' \
+  http://localhost:8000/reply
+```
+
+### Options
+
+The JSON server accepts the following command line options.
+
+```
+json-server [-host=string -port=int -debug -utf8 -forgetful -help] [path]
+```
+
+#### Server Options
+
+* `-host string`
+
+  The interface to listen on (default `"0.0.0.0"`)
+
+* `-port int`
+
+  The port number to bind to (default `8000`)
+
+#### RiveScript Options
+
+* `-debug`
+
+  Enable debug mode within RiveScript (default `false`)
+
+* `-utf8`
+
+  Enable UTF-8 mode within RiveScript (default `true`)
+
+* `-forgetful`
+
+  Do not store user variables in server memory between requests (default
+  `false`). See [User Variables](#user-variables) for more information about
+  how user variables are dealt with in this program.
+
+* `path`
+
+  Specify a path on disk where RiveScript source files (`*.rive`) can be found.
+  The default is `../brain`, or `/eg/brain` relative to the git root
+  of rivescript-go.
+
+## API Documentation
+
+### POST /reply
+
+Post a JSON message (`Content-Type: application/json`) to this endpoint to get
+a response from the chatbot.
+
+Request payload follows this format (all types are strings):
+
+```javascript
+{
+  "username": "demo",       // Unique user ID (for user variables in the bot)
+  "message": "Hello robot", // The message to send.
+  "vars": {                 // Optional user variables to include.
+    "name": "Demo User"
+  }
+}
+```
+
+The only **required** parameter is the `username`. A missing or blank `message`
+would be handled by the chatbot's fall-back `*` trigger.
+
+The response follows this format (all types are strings):
+
+```javascript
+// On successful outputs.
+{
+  "status": "ok",
+  "reply": "Hello human.",
+  "vars": {                 // All user variables the bot has for that user.
+    "topic": "random",
+    "name": "Demo User"
+  }
+}
+
+// On errors.
+{
+  "status": "error",
+  "error": "username is required"
+}
+```
+
+The only key guaranteed to be in the response is `status`. Other keys are
+excluded when empty.
+
+## User Variables
+
+The server keeps a shared RiveScript instance in memory for the lifetime of
+the program. When the server exits, the user variables are lost.
+
+The REST client that consumes this API *should* always send the full set of
+user vars that it knows about on each request. This is the safest way to keep
+consistent state for the end user. However, the client does not need to provide
+these variables; the server will temporarily use its own and send its current
+state to the client with each response.
+
+A client that cares about long-term consistency of user variables should take
+the `vars` returned by the server and store them somewhere, and send them back
+to the server on the next request. This way the server could be rebooted
+between requests and the bot won't forget the user's name, because the client
+always sends its variables to the server.
+
+To ensure that the server does not keep user variables around after the
+request, you can provide the `-forgetful` command line option to the program.
+This will clear the user's variables at the end of every request, forcing the
+REST client to manage them on their end.
+
+## Disclaimer for Deployment
+
+This code is only intended for demonstration purposes, but as a Go web server
+it can be used in a production environment. To that end, you should be aware of
+some security and performance considerations:
+
+* **The API is non-authenticated.** If the server is publicly accessible, then
+  anybody on the Internet can interact with it, providing *any* data for the
+  `username`, `message` and `vars` fields.
+
+  If this is a problem (for example, if you're implementing some sort of User
+  Access Control within RiveScript keyed off the user's username, or `<id>`),
+  then you should bind the server to a non-public interface, for example by
+  using the command line option: `-host localhost`
+
+  You could put a reverse proxy like Nginx in front of the server to provide
+  authentication on public interfaces if needed.
+
+* **The server remembers users by default.** RiveScript stores user variables in
+  memory by default, and this server doesn't change that behavior. This may be
+  a memory leak concern if your bot interacts with large amounts of distinct
+  usernames, or stores a ton of user variables per user.
+
+  To prevent the server from holding onto user variables in memory, use the
+  `-forgetful` command line option. The bot will then clear its user variables
+  after every request.
+
+  See [User Variables](#user-variables) for tips on how the client should
+  then keep track of variables on its end rather than depend on the server.
+
+## License
+
+This example is released under the same license as rivescript-go itself.

--- a/eg/json-server/index.html
+++ b/eg/json-server/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>RiveScript json-server</title>
+    <style type="text/css">
+        body {
+            background-color: #FFFFFF;
+            font-family: Helvetica,Arial,Verdana,sans-serif;
+            font-size: medium;
+            color: #000000;
+        }
+        pre, code {
+            font-family: "Ubuntu Mono", "DejaVu Sans Mono", "Lucida Console", "Monospace", monospace;
+            font-size: medium;
+        }
+        pre {
+            display: block;
+            border: 1px dashed #000000;
+            padding: 12px;
+        }
+        pre#output {
+            display: none;
+            clear: both;
+            margin: 20px 0;
+        }
+        .row {
+            clear: both;
+            padding: 4px 0;
+        }
+        .row label {
+            width: 150px;
+            float: left;
+            text-align: right;
+            padding-right: 4px;
+        }
+        .row input {
+            float: left;
+        }
+        button {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+
+<h1>RiveScript json-server</h1>
+
+Usage via <code>curl</code>:
+
+<pre>curl -X POST -H 'Content-Type: application/json' \
+    -d '{"username": "soandso", "message": "Hello, bot"}' \
+    http://localhost:8000/reply</pre>
+
+<h2>In-Browser Demo</h2>
+
+<form id="demo" action="/" method="POST">
+    <div class="row">
+        <label for="username">Username:</label> <input type="text" id="username" size="40" value="demo" placeholder="Required.">
+    </div>
+    <div class="row">
+        <label for="message">Message:</label> <input type="text" id="message" size="40" placeholder="Press Return to send." autocomplete="off">
+    </div>
+    <button type="submit"></button>
+</form>
+
+<br>
+<pre id="output"></pre>
+
+<script type="text/javascript">
+function ready(fn) {
+    if (document.readyState !== "loading") {
+        fn();
+    } else {
+        document.addEventListener('DOMContentLoaded', fn);
+    }
+}
+
+ready(function() {
+    var $form     = document.getElementById("demo");
+    var $username = document.getElementById("username");
+    var $message  = document.getElementById("message");
+    var $output   = document.getElementById("output");
+
+    var write = function(message) {
+        $output.innerText += message+"\n";
+    };
+
+    $form.addEventListener("submit", function(e) {
+        e.preventDefault();
+        $output.style.display = "block";
+        $output.innerText = "";
+        var message = $message.value;
+        $message.value = "";
+
+        var req = new XMLHttpRequest();
+        req.open("POST", "/reply");
+        req.setRequestHeader("Content-Type", "application/json; charset=utf-8");
+
+        req.onload = req.onerror = function() {
+            var data;
+            try {
+                data = JSON.parse(req.responseText);
+            } catch(e) {
+                write("Error: " + e);
+            }
+
+            if (req.status !== 200) {
+                write("Error: got non-200 status code (" + req.status + ")");
+            }
+
+            if (data.status === "error") {
+                write("API Error: " + data.error);
+            } else {
+                write("Reply: " + data.reply);
+                write("Vars: " + JSON.stringify(data.vars, null, 2));
+            }
+        }
+
+        req.send(JSON.stringify({
+            username: $username.value,
+            message: message,
+        }));
+    });
+})
+</script>
+
+</body>
+</html>

--- a/eg/json-server/main.go
+++ b/eg/json-server/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/aichaos/rivescript-go"
+	"github.com/aichaos/rivescript-go/config"
+	"github.com/aichaos/rivescript-go/lang/javascript"
+)
+
+// Bot is a global RiveScript instance to share between requests, so that the
+// bot's replies only need to be parsed and sorted one time.
+var Bot *rivescript.RiveScript
+var forgetful bool
+
+func main() {
+	// Command line arguments.
+	var (
+		port  = flag.Int("port", 8000, "Port to listen on (default 8000)")
+		host  = flag.String("host", "0.0.0.0", "Interface to listen on.")
+		debug = flag.Bool("debug", false, "Enable debug mode for RiveScript.")
+		utf8  = flag.Bool("utf8", true, "Enable UTF-8 mode")
+	)
+	flag.BoolVar(&forgetful, "forgetful", false,
+		"Do not store user variables in server memory between requests.",
+	)
+	flag.Parse()
+
+	// Set up the RiveScript bot.
+	Bot = rivescript.New(&config.Config{
+		Debug: *debug,
+		UTF8:  *utf8,
+	})
+	Bot.SetHandler("javascript", javascript.New(Bot))
+	Bot.LoadDirectory("../brain")
+	Bot.SortReplies()
+
+	http.HandleFunc("/", LogMiddleware(IndexHandler))
+	http.HandleFunc("/reply", LogMiddleware(ReplyHandler))
+
+	addr := fmt.Sprintf("%s:%d", *host, *port)
+	fmt.Printf("Server listening at http://%s/\n", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+// Type Request describes the JSON arguments to the API.
+type Request struct {
+	Username string            `json:"username"`
+	Message  string            `json:"message"`
+	Vars     map[string]string `json:"vars"`
+}
+
+// Type Response describes the JSON output from the API.
+type Response struct {
+	Status string            `json:"status"` // 'ok' or 'error'
+	Error  string            `json:"error,omitempty"`
+	Reply  string            `json:"reply,omitempty"`
+	Vars   map[string]string `json:"vars,omitempty"`
+}
+
+// ReplyHandler is the JSON endpoint for the RiveScript bot.
+func ReplyHandler(w http.ResponseWriter, r *http.Request) {
+	// Only POST allowed.
+	if r.Method != "POST" {
+		writeError(w, "This endpoint only works with POST requests.", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Get the request information.
+	if !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		writeError(w, "Content-Type of the request should be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	// Get JSON parameters.
+	var params Request
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&params)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// The username is required.
+	if params.Username == "" {
+		writeError(w, "username is required", http.StatusBadRequest)
+		return
+	}
+
+	// Let RiveScript know all the user vars of the client.
+	for k, v := range params.Vars {
+		Bot.SetUservar(params.Username, k, v)
+	}
+
+	// Get a reply from the bot.
+	reply := Bot.Reply(params.Username, params.Message)
+
+	// Retrieve all user variables from the bot.
+	var vars map[string]string
+	userdata, err := Bot.GetUservars(params.Username)
+	if err == nil {
+		vars = userdata.Variables
+	}
+
+	// Are we being forgetful?
+	if forgetful {
+		Bot.ClearUservars(params.Username)
+	}
+
+	// Prepare the JSON response.
+	w.Header().Add("Content-Type", "application/json; charset=utf-8")
+	response := Response{
+		Status: "ok",
+		Error:  "",
+		Reply:  reply,
+		Vars:   vars,
+	}
+
+	out, _ := json.MarshalIndent(response, "", "  ")
+	w.Write(out)
+}
+
+// IndexHandler is the default page handler and just shows a `curl` example.
+func IndexHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	http.ServeFile(w, r, "index.html")
+}
+
+// LogMiddleware does basic logging to the console for HTTP requests.
+func LogMiddleware(fn func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Log line looks like:
+		// [127.0.0.1] POST /reply HTTP/1.1
+		log.Printf("[%s] %s %s %s",
+			r.RemoteAddr,
+			r.Method,
+			r.URL.Path,
+			r.Proto,
+		)
+		fn(w, r)
+	}
+}
+
+// writeError handles sending JSON errors to the client.
+func writeError(w http.ResponseWriter, message string, code int) {
+	// Prepare the error JSON.
+	response, err := json.MarshalIndent(Response{
+		Status: "error",
+		Error:  message,
+	}, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Send it.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, err = w.Write(response)
+	if err != nil {
+		log.Printf("[ERROR] %s\n", err)
+	}
+}

--- a/eg/json-server/main_test.go
+++ b/eg/json-server/main_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	rivescript "github.com/aichaos/rivescript-go"
+	"github.com/aichaos/rivescript-go/config"
+)
+
+func init() {
+	Bot = rivescript.New(config.UTF8())
+	Bot.Stream(`
+		+ hello bot
+		- Hello human.
+
+		+ my name is *
+		- <set name=<formal>>Nice to meet you, <get name>.
+
+		+ what is my name
+		- Your name is <get name>.
+
+		+ i am # years old
+		- <set age=<star>>I will remember you are <get age> years old.
+
+		+ how old am i
+		- You are <get age> years old.
+	`)
+	Bot.SortReplies()
+}
+
+func TestIndex(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(IndexHandler)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("IndexHandler returned wrong status code: expected %v, got %v",
+			http.StatusOK, status,
+		)
+	}
+	_ = req
+}
+
+func TestUsernameError(t *testing.T) {
+	res := post(t, Request{
+		Message: "Hello bot",
+	})
+	assertError(t, res, "username is required")
+}
+
+func TestSimple(t *testing.T) {
+	res := post(t, Request{
+		Username: "alice",
+		Message:  "Hello bot",
+	})
+	assert(t, res, "Hello human.")
+}
+
+func TestAliceVars(t *testing.T) {
+	// The request sends all vars for the user. Assert that existing
+	// vars were changed and default ones (topic) added.
+	res := post(t, Request{
+		Username: "alice",
+		Message:  "my name is Alice",
+		Vars: map[string]string{
+			"name": "Bob",
+			"age":  "10",
+		},
+	})
+	assert(t, res, "Nice to meet you, Alice.")
+	assertVars(t, res, map[string]string{
+		"topic": "random",
+		"name":  "Alice",
+		"age":   "10",
+	})
+
+	// This request doesn't send the vars, but the server remembers the user.
+	// As long as the server is running it caches user vars.
+	res = post(t, Request{
+		Username: "alice",
+		Message:  "What is my name?",
+	})
+	assert(t, res, "Your name is Alice.")
+	assertVars(t, res, map[string]string{
+		"name":  "Alice",
+		"topic": "random",
+		"age":   "10",
+	})
+}
+
+func TestBobVars(t *testing.T) {
+	// This user will not send any vars initially, and we'll slowly build
+	// them up over time.
+	expect := map[string]string{}
+
+	// Reusable function to send a message, expect a reply, and assert
+	// a new variable was added.
+	testReply := func(message, reply string) {
+		res := post(t, Request{
+			Username: "bob",
+			Message:  message,
+		})
+		assert(t, res, reply)
+		assertVars(t, res, expect)
+	}
+
+	// The first request should only set the default topic.
+	expect["topic"] = "random"
+	testReply("Hello bot.", "Hello human.")
+
+	// Test default (missing) variables.
+	testReply("What is my name?", "Your name is undefined.")
+	testReply("How old am I?", "You are undefined years old.")
+
+	// Now we tell it our name.
+	expect["name"] = "Bob"
+	testReply("My name is Bob.", "Nice to meet you, Bob.")
+
+	// And age.
+	expect["age"] = "10"
+	testReply("I am 10 years old", "I will remember you are 10 years old.")
+}
+
+// post handles the common logic for POSTing to the /reply endpoint.
+func post(t *testing.T, params Request) Response {
+	payload, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make an HTTP Request for the handler.
+	req, err := http.NewRequest("POST", "/reply", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	// Call the handler.
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(ReplyHandler)
+	handler.ServeHTTP(rr, req)
+
+	// Read the response body.
+	body, err := ioutil.ReadAll(rr.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse it.
+	var response Response
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return response
+}
+
+// assert verifies that the request was successful and the reply was given.
+func assert(t *testing.T, res Response, expect string) {
+	if res.Status != "ok" {
+		t.Errorf("bad response status: expected 'ok', got '%v'", res.Status)
+	}
+
+	if res.Reply != expect {
+		t.Errorf(
+			"didn't get expected reply from bot\n"+
+				"expected: '%s'\n"+
+				"     got: '%s'",
+			expect,
+			res.Reply,
+		)
+	}
+}
+
+// assertVars makes sure user vars are set.
+func assertVars(t *testing.T, res Response, expect map[string]string) {
+	if !reflect.DeepEqual(res.Vars, expect) {
+		t.Errorf(
+			"user vars are not what I expected\n"+
+				"expected: %v\n"+
+				"     got: %v",
+			expect,
+			res.Vars,
+		)
+	}
+}
+
+// assertError verifies that an error was given.
+func assertError(t *testing.T, res Response, expect string) {
+	if res.Status != "error" {
+		t.Errorf("bad response status: expected 'error', got '%v'", res.Status)
+	}
+
+	if res.Error != expect {
+		t.Errorf(
+			"didn't get expected error message\n"+
+				"expected: '%s'\n"+
+				"     got: '%s'",
+			expect,
+			res.Error,
+		)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,9 +10,10 @@ package parser
 import (
 	"errors"
 	"fmt"
-	"github.com/aichaos/rivescript-go/ast"
 	"strconv"
 	"strings"
+
+	"github.com/aichaos/rivescript-go/ast"
 )
 
 const RS_VERSION float64 = 2.0
@@ -174,12 +175,14 @@ func (self *Parser) Parse(filename string, code []string) (*ast.Root, error) {
 			continue
 		}
 		cmd := string(line[0])
-		line = strings.TrimSpace(line[1:])
+		line = line[1:]
 
 		// Ignore in-line comments if there's a space before and after the "//"
 		if strings.Index(line, " // ") > -1 {
 			line = strings.Split(line, " // ")[0]
 		}
+
+		line = strings.TrimSpace(line)
 
 		// TODO: check syntax
 


### PR DESCRIPTION
This adds a JSON server example for rivescript-go.

Unlike the JSON server example in the Python version, the Go one is suitable for production use (given some caveats). As such it provides many command line options to control and tune the server's behavior.

See its README for details.

This also fixes a bug in the parser where lines weren't trimmed after inline comments are removed.