### PR TITLE
Refactor internal %Previous structure and prettify the shell

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -17,14 +17,14 @@ The tree looks like this (in JSON-style syntax):
 */
 package ast
 
-// Type Root represents the root of the AST tree.
+// Root represents the root of the AST tree.
 type Root struct {
 	Begin   Begin             `json:"begin"`
 	Topics  map[string]*Topic `json:"topics"`
 	Objects []*Object         `json:"objects"`
 }
 
-// Type Begin represents the "begin block" style data (configuration).
+// Begin represents the "begin block" style data (configuration).
 type Begin struct {
 	Global map[string]string   `json:"global"`
 	Var    map[string]string   `json:"var"`
@@ -33,14 +33,14 @@ type Begin struct {
 	Array  map[string][]string `json:"array"` // Map of string (names) to arrays-of-strings
 }
 
-// Type Topic represents a topic of conversation.
+// Topic represents a topic of conversation.
 type Topic struct {
 	Triggers []*Trigger      `json:"triggers"`
 	Includes map[string]bool `json:"includes"`
 	Inherits map[string]bool `json:"inherits"`
 }
 
-// Type Trigger has a trigger pattern and all the subsequent handlers for it.
+// Trigger has a trigger pattern and all the subsequent handlers for it.
 type Trigger struct {
 	Trigger   string   `json:"trigger"`
 	Reply     []string `json:"reply"`
@@ -49,7 +49,7 @@ type Trigger struct {
 	Previous  string   `json:"previous"`
 }
 
-// Type Object contains source code of dynamically parsed object macros.
+// Object contains source code of dynamically parsed object macros.
 type Object struct {
 	Name     string   `json:"name"`
 	Language string   `json:"language"`
@@ -58,21 +58,21 @@ type Object struct {
 
 // New creates a new, empty, abstract syntax tree.
 func New() *Root {
-	ast := new(Root)
-
-	// Initialize all the structures.
-	ast.Begin.Global = map[string]string{}
-	ast.Begin.Var = map[string]string{}
-	ast.Begin.Sub = map[string]string{}
-	ast.Begin.Person = map[string]string{}
-	ast.Begin.Array = map[string][]string{}
+	ast := &Root{
+		// Initialize all the structures.
+		Begin: Begin{
+			Global: map[string]string{},
+			Var:    map[string]string{},
+			Sub:    map[string]string{},
+			Person: map[string]string{},
+			Array:  map[string][]string{},
+		},
+		Topics:  map[string]*Topic{},
+		Objects: []*Object{},
+	}
 
 	// Initialize the 'random' topic.
-	ast.Topics = map[string]*Topic{}
 	ast.AddTopic("random")
-
-	// Objects
-	ast.Objects = []*Object{}
 
 	return ast
 }

--- a/doc_test.go
+++ b/doc_test.go
@@ -1,4 +1,4 @@
-package rivescript
+package rivescript_test
 
 import (
 	"fmt"
@@ -108,7 +108,7 @@ func ExampleRiveScript_subroutine() {
 
 	// Define an object macro named `setname`
 	bot.SetSubroutine("setname", func(rs *rss.RiveScript, args []string) string {
-		uid := rs.CurrentUser()
+		uid, _ := rs.CurrentUser()
 		rs.SetUservar(uid, args[0], args[1])
 		return ""
 	})

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -48,9 +48,7 @@ type Parser struct {
 
 // New creates and returns a new instance of a RiveScript Parser.
 func New(config ParserConfig) *Parser {
-	self := new(Parser)
-	self.C = config
-	return self
+	return &Parser{config}
 }
 
 // say proxies to the OnDebug handler.

--- a/rivescript_test.go
+++ b/rivescript_test.go
@@ -1,0 +1,57 @@
+package rivescript_test
+
+// This test file contains the unit tests that had to be segregated from the
+// others in the `src/` package.
+//
+// The only one here so far is an object macro test. It needed to use the public
+// RiveScript API because the JavaScript handler expects an object of that type,
+// and so it couldn't be in the `src/` package or it would create a dependency
+// cycle.
+
+import (
+	"testing"
+
+	rivescript "github.com/aichaos/rivescript-go"
+	"github.com/aichaos/rivescript-go/lang/javascript"
+)
+
+// This one has to test the public interface because of the JavaScript handler
+// expecting a *RiveScript of the correct color.
+func TestJavaScript(t *testing.T) {
+	rs := rivescript.New(nil)
+	rs.SetHandler("javascript", javascript.New(rs))
+	rs.Stream(`
+		> object reverse javascript
+			var msg = args.join(" ");
+			return msg.split("").reverse().join("");
+		< object
+
+		> object nolang
+			return "No language provided!"
+		< object
+
+		+ reverse *
+		- <call>reverse <star></call>
+
+		+ no lang
+		- <call>nolang</call>
+	`)
+	rs.SortReplies()
+
+	// Helper function to assert replies via the public interface.
+	assert := func(input, expected string) {
+		reply, err := rs.Reply("local-user", input)
+		if err != nil {
+			t.Errorf("Got error when trying to get a reply: %v", err)
+		} else if reply != expected {
+			t.Errorf("Got unexpected reply. Expected %s, got %s", expected, reply)
+		}
+	}
+
+	assert("reverse hello world", "dlrow olleh")
+	assert("no lang", "[ERR: Object Not Found]")
+
+	// Disable support.
+	rs.RemoveHandler("javascript")
+	assert("reverse hello world", "[ERR: Object Not Found]")
+}

--- a/src/astmap.go
+++ b/src/astmap.go
@@ -54,12 +54,3 @@ type astObject struct {
 	language string
 	code     []string
 }
-
-// This is like astTopic but is just for %Previous mapping
-type thatTopic struct {
-	triggers map[string]*thatTrigger
-}
-
-type thatTrigger struct {
-	previous map[string]*astTrigger
-}

--- a/src/object_test.go
+++ b/src/object_test.go
@@ -3,51 +3,7 @@ package rivescript
 import (
 	"strings"
 	"testing"
-
-	rivescript "github.com/aichaos/rivescript-go"
-	"github.com/aichaos/rivescript-go/lang/javascript"
 )
-
-// This one has to test the public interface because of the JavaScript handler
-// expecting a *RiveScript of the correct color.
-func TestJavaScript(t *testing.T) {
-	rs := rivescript.New(nil)
-	rs.SetHandler("javascript", javascript.New(rs))
-	rs.Stream(`
-		> object reverse javascript
-			var msg = args.join(" ");
-			return msg.split("").reverse().join("");
-		< object
-
-		> object nolang
-			return "No language provided!"
-		< object
-
-		+ reverse *
-		- <call>reverse <star></call>
-
-		+ no lang
-		- <call>nolang</call>
-	`)
-	rs.SortReplies()
-
-	// Helper function to assert replies via the public interface.
-	assert := func(input, expected string) {
-		reply, err := rs.Reply("local-user", input)
-		if err != nil {
-			t.Errorf("Got error when trying to get a reply: %v", err)
-		} else if reply != expected {
-			t.Errorf("Got unexpected reply. Expected %s, got %s", expected, reply)
-		}
-	}
-
-	assert("reverse hello world", "dlrow olleh")
-	assert("no lang", "[ERR: Object Not Found]")
-
-	// Disable support.
-	rs.RemoveHandler("javascript")
-	assert("reverse hello world", "[ERR: Object Not Found]")
-}
 
 // Mock up an object macro handler for the private API testing, for code
 // coverage. The MockHandler just returns its text as a string.

--- a/src/parser.go
+++ b/src/parser.go
@@ -78,23 +78,6 @@ func (rs *RiveScript) parse(path string, lines []string) error {
 			trigger.previous = trig.Previous
 
 			rs.topics[topic].triggers = append(rs.topics[topic].triggers, trigger)
-
-			// Does this one have a %Previous? If so, make a pointer to this
-			// exact trigger in rs.thats
-			if trigger.previous != "" {
-				// Initialize the structure first.
-				if _, ok := rs.thats[topic]; !ok {
-					rs.thats[topic] = new(thatTopic)
-					rs.say("%q", rs.thats[topic])
-					rs.thats[topic].triggers = map[string]*thatTrigger{}
-				}
-				if _, ok := rs.thats[topic].triggers[trigger.trigger]; !ok {
-					rs.say("%q", rs.thats[topic].triggers[trigger.trigger])
-					rs.thats[topic].triggers[trigger.trigger] = new(thatTrigger)
-					rs.thats[topic].triggers[trigger.trigger].previous = map[string]*astTrigger{}
-				}
-				rs.thats[topic].triggers[trigger.trigger].previous[trigger.previous] = trigger
-			}
 		}
 	}
 

--- a/src/sorting.go
+++ b/src/sorting.go
@@ -28,13 +28,13 @@ func (rs *RiveScript) SortReplies() error {
 		// Collect a list of all the triggers we're going to worry about. If this
 		// topic inherits another topic, we need to recursively add those to the
 		// list as well.
-		allTriggers := rs.getTopicTriggers(topic, rs.topics, nil)
+		allTriggers := rs.getTopicTriggers(topic, false)
 
 		// Sort these triggers.
 		rs.sorted.topics[topic] = rs.sortTriggerSet(allTriggers, true)
 
 		// Get all of the %Previous triggers for this topic.
-		thatTriggers := rs.getTopicTriggers(topic, nil, rs.thats)
+		thatTriggers := rs.getTopicTriggers(topic, true)
 
 		// And sort them, too.
 		rs.sorted.thats[topic] = rs.sortTriggerSet(thatTriggers, false)


### PR DESCRIPTION
@marceloverdijk found an optimization in RiveScript-Java which allowed for getting rid of the redundant `rs.thats` structure. This implements that fix for the Go version.

It also cleans up some of the code and adds new features to the `cmd/rivescript` shell:

* ANSI color codes to visually identify prompt/response lines (helpful when debugging is enabled); disable colors using the `-nocolor` option.
* New command to toggle debug mode: `/debug true` or `/debug false`
* New command to print internal data structures: `/dump topics` or `/dump sorted`

![screenshot from 2017-02-07 20-30-11](https://cloud.githubusercontent.com/assets/1663507/22723563/5ffa55c4-ed74-11e6-842d-ae87748f0b75.png)

And finally, this fixes a couple small bugs:

* `GetGlobal()` and `SetGlobal()` now correctly toggle the special globals "debug" and "depth". Values like "true", "t", "on", and "yes" enables debug mode and other values disable it.
* Move a unit test to prevent a cyclic dependency error when running tests from a standard GOPATH (i.e., not using `make test`).