### PR TITLE
Add a Redis session driver for RiveScript

### DIFF
--- a/rivescript.go
+++ b/rivescript.go
@@ -57,7 +57,7 @@ func New(cfg *Config) *RiveScript {
 		cfg.Depth = 50
 	}
 
-	bot.rs.Configure(cfg.Debug, cfg.Strict, cfg.UTF8, cfg.Depth, memory.New())
+	bot.rs.Configure(cfg.Debug, cfg.Strict, cfg.UTF8, cfg.Depth, cfg.SessionManager)
 
 	return bot
 }

--- a/sessions/interface.go
+++ b/sessions/interface.go
@@ -62,17 +62,17 @@ type SessionManager interface {
 // HistorySize is the number of entries stored in the history.
 const HistorySize int = 9
 
-// Type UserData is a container for user variables.
+// UserData is a container for user variables.
 type UserData struct {
-	Variables map[string]string
-	LastMatch string
-	*History
+	Variables map[string]string `json:"vars"`
+	LastMatch string            `json:"lastMatch"`
+	*History  `json:"history"`
 }
 
-// Type History keeps track of recent input and reply history.
+// History keeps track of recent input and reply history.
 type History struct {
-	Input []string
-	Reply []string
+	Input []string `json:"input"`
+	Reply []string `json:"reply"`
 }
 
 // NewHistory creates a new History object with the history arrays filled out.

--- a/sessions/redis/README.md
+++ b/sessions/redis/README.md
@@ -1,0 +1,74 @@
+# Redis Sessions for RiveScript
+
+[![GoDoc](https://godoc.org/github.com/aichaos/rivescript-go/sessions/redis?status.svg)](https://godoc.org/github.com/aichaos/rivescript-go/sessions/redis)
+
+This package provides support for using a [Redis cache](https://redis.io/) to
+store user variables for RiveScript.
+
+```bash
+go get github.com/aichaos/rivescript-go/sessions/redis
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+
+    rivescript "github.com/aichaos/rivescript-go"
+    "github.com/aichaos/rivescript-go/sessions/redis"
+    goRedis "gopkg.in/redis.v5"
+)
+
+func main() {
+    // Verbose example with ALL options spelled out. All the settings are
+    // optional, and their default values are shown here.
+    bot := rivescript.New(&rivescript.Config{
+        // Initialize the Redis session manager here.
+        SessionManager: redis.New(&redis.Config{
+            // The prefix is added before all the usernames in the Redis cache.
+            // For a username of 'alice' it would go into 'rivescript/alice'
+            Prefix: "rivescript/",
+
+            // The prefix used to store 'frozen' copies of user variables. The
+            // default takes the form "frozen:<prefix>" using your Prefix,
+            // so this field is doubly optional unless you wanna customize it.
+            FrozenPrefix: "frozen:rivescript/",
+
+            // If you need to configure the underlying Redis instance, you can
+            // pass its options along here.
+            Redis: &goRedis.Options{
+                Addr: "localhost:6379",
+                DB:   0,
+            },
+        }),
+    })
+
+    // A minimal version of the above that uses all the default options.
+    bot = rivescript.New(&rivescript.Config{
+        SessionManager: redis.New(nil),
+    })
+
+    bot.LoadDirectory("eg/brain")
+    bot.SortReplies()
+
+    // And go on as normal.
+    reply, err := bot.Reply("soandso", "hello bot")
+    if err != nil {
+        fmt.Printf("Error: %s\n", err)
+    } else {
+        fmt.Printf("Reply: %s\n", reply)
+    }
+}
+```
+
+## Testing
+
+Running these unit tests requires a local Redis server to be running. In the
+future I'll look into mocking the server.
+
+## License
+
+Released under the same terms as RiveScript itself (MIT license).

--- a/sessions/redis/extra.go
+++ b/sessions/redis/extra.go
@@ -1,0 +1,99 @@
+package redis
+
+// NOTE: This file contains added functions above and beyond the SessionManager
+// implementation.
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aichaos/rivescript-go/sessions"
+)
+
+// key generates a key name to use in Redis.
+func (s *Session) key(username string) string {
+	return s.prefix + username
+}
+
+// frozenKey generates the 'frozen' key name to use in Redis.
+func (s *Session) frozenKey(username string) string {
+	return s.frozenPrefix + username
+}
+
+// getRedis gets a UserData out of the Redis cache.
+func (s *Session) getRedis(username string) (*sessions.UserData, error) {
+	data, err := s.getRedisFrozen(username, false)
+	return data, err
+}
+
+// getRedisFrozen is the implementation behind getRedis and allows for the
+// key to be overridden with the 'frozen' version.
+func (s *Session) getRedisFrozen(username string, frozen bool) (*sessions.UserData, error) {
+	var key string
+	if frozen {
+		key = s.frozenKey(username)
+	} else {
+		key = s.key(username)
+	}
+
+	// Check Redis for the key.
+	value, err := s.client.Get(key).Result()
+	if err != nil {
+		return nil, fmt.Errorf(
+			`no data for username "%s": %s`,
+			username, err,
+		)
+	}
+
+	// Decode the JSON.
+	var user *sessions.UserData
+	err = json.Unmarshal([]byte(value), &user)
+	if err != nil {
+		return nil, fmt.Errorf(
+			`JSON unmarshal error for username "%s": %s`,
+			username, err,
+		)
+	}
+
+	return user, nil
+}
+
+// putRedis puts a UserData into the Redis cache.
+func (s *Session) putRedis(username string, data *sessions.UserData) {
+	s.putRedisFrozen(username, data, false)
+}
+
+// putRedisFrozen is the implementation behind putRedis and allows for the
+// key to be overridden with the 'frozen' version.
+func (s *Session) putRedisFrozen(username string, data *sessions.UserData, frozen bool) error {
+	// Which key to use?
+	var key string
+	if frozen {
+		key = s.frozenKey(username)
+	} else {
+		key = s.key(username)
+	}
+
+	encoded, err := json.MarshalIndent(data, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	err = s.client.Set(key, string(encoded), 0).Err()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// defaultSession initializes the default session variables for a user.
+func defaultSession() *sessions.UserData {
+	return &sessions.UserData{
+		Variables: map[string]string{
+			"topic": "random",
+		},
+		LastMatch: "",
+		History:   sessions.NewHistory(),
+	}
+}

--- a/sessions/redis/integration_test.go
+++ b/sessions/redis/integration_test.go
@@ -1,0 +1,87 @@
+package redis_test
+
+import (
+	"testing"
+
+	rivescript "github.com/aichaos/rivescript-go"
+	"github.com/aichaos/rivescript-go/sessions"
+	"github.com/aichaos/rivescript-go/sessions/redis"
+)
+
+// This script tests the 'integration' of the RiveScript public API with the
+// RiveScript-Redis public API.
+
+func TestIntegration(t *testing.T) {
+	bot := rivescript.New(&rivescript.Config{
+		SessionManager: redis.New(&redis.Config{
+			Prefix: "rivescript:integration/",
+		}),
+	})
+	bot.Stream(`
+        + hello bot
+        - Hello human.
+
+        + my name is *
+        - <set name=<formal>>Nice to meet you, <get name>.
+
+        + who am i
+        - Your name is <get name>.
+
+        + i am # years old
+        - <set age=<star>>I will remember you are <get age> years old.
+
+        + how old am i
+        - You are <get age>.
+
+        + today is my birthday
+        - <add age=1>Happy birthday!
+    `)
+	expectVar(t, bot, "alice", "name", "")
+	bot.SortReplies()
+
+	// See if Redis can remember things.
+	expectReply(t, bot, "alice", "my name is Alice", "Nice to meet you, Alice.")
+	expectReply(t, bot, "alice", "I am 5 years old", "I will remember you are 5 years old.")
+	expectVar(t, bot, "alice", "name", "Alice")
+	expectVar(t, bot, "alice", "age", "5")
+
+	// Freeze variables and restore them.
+	bot.FreezeUservars("alice")
+	expectReply(t, bot, "alice", "Today is my birthday", "Happy birthday!")
+	expectVar(t, bot, "alice", "age", "6")
+	bot.ThawUservars("alice", sessions.Thaw)
+	expectVar(t, bot, "alice", "age", "5")
+
+	// Clean up.
+	bot.ClearAllUservars()
+}
+
+func expectReply(t *testing.T, bot *rivescript.RiveScript, username, input, expected string) {
+	reply, _ := bot.Reply(username, input)
+	if reply != expected {
+		t.Errorf(
+			"got unexpected reply for: [%s] %s\n"+
+				"expected: %s\n"+
+				"     got: %s",
+			username,
+			input,
+			expected,
+			reply,
+		)
+	}
+}
+
+func expectVar(t *testing.T, bot *rivescript.RiveScript, username, name, expected string) {
+	value, _ := bot.GetUservar(username, name)
+	if value != expected {
+		t.Errorf(
+			"got unexpected user variable for user '%s'\n"+
+				"expected: '%s'='%s'\n"+
+				"     got: '%s'",
+			username,
+			name,
+			expected,
+			value,
+		)
+	}
+}

--- a/sessions/redis/internal_test.go
+++ b/sessions/redis/internal_test.go
@@ -1,0 +1,284 @@
+package redis
+
+// This tests the internal interface of just the Redis specific bits,
+// independent of RiveScript. At time of writing, this test file gets
+// us to 93.4% coverage!
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aichaos/rivescript-go/sessions"
+)
+
+// newTest creates a new test environment with a new Redis prefix.
+// The generated prefix takes the form: `redis_test:<PID>:<name>`
+func newTest(name string) *Session {
+	s := New(&Config{
+		Prefix: fmt.Sprintf("rivescript:%d:%s/", os.Getpid(), name),
+	})
+	s.ClearAll()
+	return s
+}
+
+// tearDown deletes a Redis prefix after the test is done.
+func tearDown(s *Session) {
+	s.ClearAll()
+}
+
+func TestRedis(t *testing.T) {
+	s := newTest("main")
+	defer tearDown(s)
+
+	// There should be no user data yet.
+	s.expectCount(t, 0)
+
+	// Create the first user.
+	{
+		username := "alice"
+
+		s.Set(username, map[string]string{
+			"name": "Alice",
+		})
+
+		// Sanity check that the default topic was implied with that.
+		s.checkVariable(t, username, "topic", "random", false)
+
+		// Check the variable we just set, and one we didn't.
+		s.checkVariable(t, username, "name", "Alice", false)
+		s.checkVariable(t, username, "age", "5", true)
+
+		// See if we have as many variables as we expect.
+		vars, _ := s.GetAny(username)
+		if len(vars.Variables) != 2 {
+			t.Errorf(
+				"expected to have 2 variables, but had %d: %v",
+				len(vars.Variables),
+				vars.Variables,
+			)
+		}
+
+		// She should have an empty history.
+		history, _ := s.GetHistory(username)
+		for i := 0; i < sessions.HistorySize; i++ {
+			if history.Input[i] != "undefined" {
+				t.Errorf(
+					"expected to have a blank history, but input[%d] = %s",
+					i,
+					history.Input[i],
+				)
+			}
+			if history.Reply[i] != "undefined" {
+				t.Errorf(
+					"expected to have a blank history, but reply[%d] = %s",
+					i,
+					history.Reply[i],
+				)
+			}
+		}
+
+		// Add some history.
+		s.AddHistory(username, "hello bot", "hello human")
+		history, _ = s.GetHistory(username)
+		if history.Input[0] != "hello bot" {
+			t.Errorf(
+				"got unexpected input history: expected 'hello bot', got %s",
+				history.Input[0],
+			)
+		}
+		if history.Reply[0] != "hello human" {
+			t.Errorf(
+				"got unexpected reply history: expected 'hello human', got %s",
+				history.Reply[0],
+			)
+		}
+
+		// LastMatch.
+		lastMatch, _ := s.GetLastMatch(username)
+		if lastMatch != "" {
+			t.Errorf(
+				"didn't expect to have a LastMatch, but had: %s",
+				lastMatch,
+			)
+		}
+		s.SetLastMatch(username, "hello bot")
+		lastMatch, _ = s.GetLastMatch(username)
+		if lastMatch != "hello bot" {
+			t.Errorf(
+				"LastMatch wasn't '%s' like I expected, but was: %s",
+				"hello bot",
+				lastMatch,
+			)
+		}
+
+		// Verify we only have one user so far.
+		s.expectCount(t, 1)
+	}
+
+	// Create the second user.
+	{
+		username := "bob"
+
+		s.Init(username)
+
+		// Verify we now have two users.
+		s.expectCount(t, 2)
+
+		// Delete this user.
+		s.Clear(username)
+
+		// We should be back to one.
+		s.expectCount(t, 1)
+	}
+
+	// Create the new second user.
+	{
+		username := "barry"
+
+		// Set some variables.
+		s.Set(username, map[string]string{
+			"name":   "Barry",
+			"age":    "20",
+			"gender": "male",
+		})
+
+		// Freeze his variables.
+		s.Freeze(username)
+
+		// Happy birthday!
+		birthday := map[string]string{
+			"age": "21",
+		}
+		s.Set(username, birthday)
+
+		// Thaw the variables and make sure it was restored.
+		s.Thaw(username, sessions.Thaw)
+		s.checkVariable(t, username, "age", "20", false)
+
+		// Make sure trying to thaw again gives an error because the frozen
+		// copy isn't there.
+		err := s.Thaw(username, sessions.Thaw)
+		expectError(t, "thawing again after sessions.Thaw", err)
+
+		// Freeze it again and repeat.
+		s.Freeze(username)
+		s.Set(username, birthday)
+
+		// Thaw with the 'keep' option this time.
+		s.Thaw(username, sessions.Keep)
+		s.checkVariable(t, username, "age", "20", false)
+
+		// One more time. The frozen copy is still there so just update
+		// the user var and try the last thaw option.
+		s.Set(username, birthday)
+
+		// Discard should just delete the frozen copy and not restore it.
+		s.Thaw(username, sessions.Discard)
+		s.checkVariable(t, username, "age", "20", false)
+
+		// One last call to Thaw should error out now.
+		err = s.Thaw(username, sessions.Thaw)
+		expectError(t, "thawing again after discard", err)
+	}
+
+	// Create the third and fourth users.
+	{
+		s.Init("charlie")
+		s.Init("dave")
+		s.expectCount(t, 4)
+
+		// Clear all data and expect to have nothing left.
+		s.ClearAll()
+		s.expectCount(t, 0)
+	}
+
+	// Test all the error cases.
+	{
+		var err error
+
+		_, err = s.Get("nobody", "name")
+		expectError(t, "get variable from missing user", err)
+
+		_, err = s.GetAny("nobody")
+		expectError(t, "get any variables for missing user", err)
+
+		_, err = s.GetLastMatch("nobody")
+		expectError(t, "get a LastMatch for missing user", err)
+
+		_, err = s.GetHistory("nobody")
+		expectError(t, "get history for missing user", err)
+
+		err = s.Freeze("nobody")
+		expectError(t, "freeze missing user", err)
+
+		s.Init("nobody")
+		s.Freeze("nobody")
+		err = s.Thaw("nobody", 42)
+		expectError(t, "invalid thaw action", err)
+	}
+}
+
+// checkVariable handles tests on user variables.
+func (s *Session) checkVariable(t *testing.T, username, name, expected string, expectError bool) {
+	value, err := s.Get(username, name)
+
+	// Got an error when we aren't expecting one?
+	if err != nil {
+		if !expectError {
+			t.Errorf(
+				"got an unexpected error when getting variable '%s' for %s: %s",
+				name,
+				username,
+				err,
+			)
+		}
+		return
+	}
+
+	// Didn't get an error when we expected to?
+	if err == nil {
+		if expectError {
+			t.Errorf(
+				"was expecting an error when getting variable '%s' for %s, but did not get one",
+				name,
+				username,
+			)
+		}
+		return
+	}
+
+	// Was it what we expected?
+	if value != expected {
+		t.Errorf(
+			"got unexpected user variable '%s' for %s:\n"+
+				"expected: %s\n"+
+				"     got: %s",
+			name,
+			username,
+			expected,
+			value,
+		)
+	}
+}
+
+// expectCount expects the user count from GetAll() to be a certain number.
+func (s *Session) expectCount(t *testing.T, expect int) {
+	users := s.GetAll()
+	if len(users) != expect {
+		t.Errorf(
+			"expected to have %d users, but had: %d",
+			expect,
+			len(users),
+		)
+	}
+}
+
+func expectError(t *testing.T, name string, err error) {
+	if err == nil {
+		t.Errorf(
+			"expected to get an error from '%s', but did not get one",
+			name,
+		)
+	}
+}

--- a/sessions/redis/redis.go
+++ b/sessions/redis/redis.go
@@ -1,0 +1,231 @@
+// Package redis implements a Redis backed session manager for RiveScript.
+package redis
+
+// NOTE: This source file contains the implementation of a SessionManager.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aichaos/rivescript-go/sessions"
+	redis "gopkg.in/redis.v5"
+)
+
+// Config allows for configuring the Redis instance and key prefix.
+type Config struct {
+	// The key prefix to use in Redis. For example, with a username of 'alice',
+	// the Redis key might be 'rivescript/alice'.
+	//
+	// The default prefix is 'rivescript/'
+	Prefix string
+
+	// The key used to prefix frozen user variables (those created by
+	// `Freeze()`). The default is `frozen:<prefix>`
+	FrozenPrefix string
+
+	// Settings for the Redis client.
+	Redis *redis.Options
+}
+
+// Session wraps a Redis client connection.
+type Session struct {
+	prefix       string
+	frozenPrefix string
+	client       *redis.Client
+}
+
+// New creates a new Redis session instance.
+func New(options *Config) *Session {
+	// No options given?
+	if options == nil {
+		options = &Config{}
+	}
+
+	// Default prefix is 'rivescript/'
+	if options.Prefix == "" {
+		options.Prefix = "rivescript/"
+	}
+	if options.FrozenPrefix == "" {
+		options.FrozenPrefix = "frozen:" + options.Prefix
+	}
+
+	// Default options for Redis if none provided.
+	if options.Redis == nil {
+		options.Redis = &redis.Options{
+			Addr: "localhost:6379",
+			DB:   0,
+		}
+	}
+
+	return &Session{
+		prefix:       options.Prefix,
+		frozenPrefix: options.FrozenPrefix,
+		client:       redis.NewClient(options.Redis),
+	}
+}
+
+// Init makes sure that a username has a session (creates one if not), and
+// returns the pointer to it in any event.
+func (s *Session) Init(username string) *sessions.UserData {
+	// See if they have any data in Redis, and return it if so.
+	user, err := s.getRedis(username)
+	if err == nil {
+		return user
+	}
+
+	// Create the default session.
+	user = defaultSession()
+
+	// Put them in Redis.
+	s.putRedis(username, user)
+	return user
+}
+
+// Set puts a user variable into Redis.
+func (s *Session) Set(username string, vars map[string]string) {
+	data := s.Init(username)
+
+	for key, value := range vars {
+		data.Variables[key] = value
+	}
+
+	s.putRedis(username, data)
+}
+
+// AddHistory adds to a user's history data.
+func (s *Session) AddHistory(username, input, reply string) {
+	data := s.Init(username)
+
+	// Pop, unshift, pop, unshift.
+	data.History.Input = data.History.Input[:len(data.History.Input)-1]
+	data.History.Input = append([]string{strings.TrimSpace(input)}, data.History.Input...)
+	data.History.Reply = data.History.Reply[:len(data.History.Reply)-1]
+	data.History.Reply = append([]string{strings.TrimSpace(reply)}, data.History.Reply...)
+
+	s.putRedis(username, data)
+}
+
+// SetLastMatch sets the user's last matched trigger.
+func (s *Session) SetLastMatch(username, trigger string) {
+	data := s.Init(username)
+	data.LastMatch = trigger
+	s.putRedis(username, data)
+}
+
+// Get a user variable out of Redis.
+func (s *Session) Get(username, name string) (string, error) {
+	data, err := s.getRedis(username)
+	if err != nil {
+		return "", err
+	}
+
+	value, ok := data.Variables[name]
+	if !ok {
+		return "", fmt.Errorf(`variable "%s" for user "%s" not set`, name, username)
+	}
+	return value, nil
+}
+
+// GetAny returns all variables about a user.
+func (s *Session) GetAny(username string) (*sessions.UserData, error) {
+	// Check redis.
+	data, err := s.getRedis(username)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// GetAll gets all data for all users.
+func (s *Session) GetAll() map[string]*sessions.UserData {
+	result := map[string]*sessions.UserData{}
+
+	keys, err := s.client.Keys(s.prefix + "*").Result()
+	if err != nil {
+		return result
+	}
+
+	for _, key := range keys {
+		username := strings.Replace(key, s.prefix, "", 1)
+		data, _ := s.GetAny(username)
+		result[username] = data
+	}
+
+	return result
+}
+
+// GetLastMatch retrieves the user's last matched trigger.
+func (s *Session) GetLastMatch(username string) (string, error) {
+	data, err := s.getRedis(username)
+	if err != nil {
+		return "", err
+	}
+
+	return data.LastMatch, nil
+}
+
+// GetHistory gets the user's history.
+func (s *Session) GetHistory(username string) (*sessions.History, error) {
+	data, err := s.getRedis(username)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.History, nil
+}
+
+// Clear deletes all variables about a user.
+func (s *Session) Clear(username string) {
+	s.client.Del(s.prefix + username)
+}
+
+// ClearAll resets all user data for all users.
+func (s *Session) ClearAll() {
+	// List all the users.
+	keys, err := s.client.Keys(s.prefix + "*").Result()
+	if err != nil {
+		return
+	}
+
+	// Delete them all.
+	s.client.Del(keys...)
+}
+
+// Freeze makes a snapshot of user variables.
+func (s *Session) Freeze(username string) error {
+	data, err := s.getRedis(username)
+	if err != nil {
+		return err
+	}
+
+	// Duplicate it into the frozen Redis key.
+	return s.putRedisFrozen(username, data, true)
+}
+
+// Thaw restores user variables from a snapshot.
+func (s *Session) Thaw(username string, action sessions.ThawAction) error {
+	frozen, err := s.getRedisFrozen(username, true)
+	if err != nil {
+		return fmt.Errorf(`no frozen data for username "%s": %s`, username, err)
+	}
+
+	// Which type of thaw action are they using?
+	switch action {
+	case sessions.Thaw:
+		// Thaw means to restore the frozen copy and then delete the copy.
+		s.Clear(username)
+		s.putRedis(username, frozen)
+		s.client.Del(s.frozenKey(username))
+	case sessions.Discard:
+		// Discard means to just delete the frozen copy, do not restore it.
+		s.client.Del(s.frozenKey(username))
+	case sessions.Keep:
+		// Keep restores from the frozen copy, but keeps the frozen copy.
+		s.Clear(username)
+		s.putRedis(username, frozen)
+	default:
+		return fmt.Errorf(`can't thaw data for username "%s": invalid thaw action`, username)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds a Redis session manager driver for RiveScript.

```go
package main

import (
    "fmt"

    rivescript "github.com/aichaos/rivescript-go"
    "github.com/aichaos/rivescript-go/sessions/redis"
    goRedis "gopkg.in/redis.v5"
)

func main() {
    // Verbose example with ALL options spelled out. All the settings are
    // optional, and their default values are shown here.
    bot := rivescript.New(&rivescript.Config{
        // Initialize the Redis session manager here.
        SessionManager: redis.New(&redis.Config{
            // The prefix is added before all the usernames in the Redis cache.
            // For a username of 'alice' it would go into 'rivescript/alice'
            Prefix: "rivescript/",

            // The prefix used to store 'frozen' copies of user variables. The
            // default takes the form "frozen:<prefix>" using your Prefix,
            // so this field is doubly optional unless you wanna customize it.
            FrozenPrefix: "frozen:rivescript/",

            // If you need to configure the underlying Redis instance, you can
            // pass its options along here.
            Redis: &goRedis.Options{
                Addr: "localhost:6379",
                DB:   0,
            },
        }),
    })

    // A minimal version of the above that uses all the default options.
    bot = rivescript.New(&rivescript.Config{
        SessionManager: redis.New(nil),
    })

    bot.LoadDirectory("eg/brain")
    bot.SortReplies()

    // And go on as normal.
    reply, err := bot.Reply("soandso", "hello bot")
    if err != nil {
        fmt.Printf("Error: %s\n", err)
    } else {
        fmt.Printf("Reply: %s\n", reply)
    }
}
```

It also fixes some bugs within RiveScript itself:

* A bug in the constructor meant RiveScript kept using the in-memory session manager regardless of one you passed in (fixes #23)
* Adds JSON tags to the session manager data types so that drivers like Redis can easily marshal/unmarshal them.