### PR TITLE
Fix test page for JSON server example in Safari

### DIFF
--- a/eg/json-server/index.html
+++ b/eg/json-server/index.html
@@ -37,7 +37,8 @@
             float: left;
         }
         button {
-            display: none;
+            visibility: hidden;
+            user-select: none;
         }
     </style>
 </head>
@@ -60,7 +61,7 @@ Usage via <code>curl</code>:
     <div class="row">
         <label for="message">Message:</label> <input type="text" id="message" size="40" placeholder="Press Return to send." autocomplete="off">
     </div>
-    <button type="submit"></button>
+    <button type="submit">Submit</button>
 </form>
 
 <br>


### PR DESCRIPTION
Safari (and probably other browsers) drop the submit button when it's
empty as well as seem to ignore submission via the return key when
`display: none` is set on the button. Weird.