### PR TITLE
Fixes for the RiveScript Test Suite (aichaos/rsts)

### DIFF
--- a/src/regexp.go
+++ b/src/regexp.go
@@ -4,7 +4,7 @@ import "regexp"
 
 // Commonly used regular expressions.
 var (
-	reWeight        = regexp.MustCompile(`\{weight=(\d+)\}`)
+	reWeight        = regexp.MustCompile(`\s*\{weight=(\d+)\}\s*`)
 	reInherits      = regexp.MustCompile(`\{inherits=(\d+)\}`)
 	reMeta          = regexp.MustCompile(`[\<>]+`)
 	reSymbols       = regexp.MustCompile(`[.?,!;:@#$%^&*()]+`)
@@ -12,6 +12,7 @@ var (
 	reZerowidthstar = regexp.MustCompile(`^\*$`)
 	reOptional      = regexp.MustCompile(`\[(.+?)\]`)
 	reArray         = regexp.MustCompile(`@(.+?)\b`)
+	reReplyArray    = regexp.MustCompile(`\(@([A-Za-z0-9_]+)\)`)
 	reBotvars       = regexp.MustCompile(`<bot (.+?)>`)
 	reUservars      = regexp.MustCompile(`<get (.+?)>`)
 	reInput         = regexp.MustCompile(`<input([1-9])>`)


### PR DESCRIPTION
This fixes a couple of bugs/implements features in RiveScript to get unit tests to pass from the [RiveScript Test Suite](https://github.com/aichaos/rsts). See also: https://github.com/aichaos/rsts/pull/1

This puts the Go version on par feature-wise with the JavaScript and Java versions.

Bugs fixed:

* Remove extra spaces around a `{weight}` tag (example: `+ hello {weight=5}`)
* Fix the `_` wildcard not matching Unicode symbols
* Implement arrays in replies expanding out to `{random}` tags