### PR TITLE
Func in loading.go to load multiple directories

### DIFF
--- a/loading.go
+++ b/loading.go
@@ -89,6 +89,62 @@ func (rs *RiveScript) LoadDirectory(path string, extensions ...string) error {
 }
 
 /*
+LoadMultipleDirectory loads multiple RiveScript documents from a comma separated list of folders on disk.
+
+Parameters
+
+	comma separated list of paths: Paths to the directorys on disk
+	extensions...: List of file extensions to filter on, default is
+	               '.rive' and '.rs'
+*/
+func (rs *RiveScript) LoadMultipleDirectory(paths []string, extensions ...string) error {
+	var files []string
+	if len(extensions) == 0 {
+		extensions = []string{".rive", ".rs"}
+	}
+	for _, path := range paths {
+		f, err := filepath.Glob(fmt.Sprintf("%s/*", path))
+		if err != nil {
+			return fmt.Errorf("Failed to open folder %s: %s", path, err)
+		}
+		for _, line := range f {
+			files = append(files, line)
+		}
+	}
+
+	// No files matched?
+	if len(files) == 0 {
+		return fmt.Errorf("No RiveScript source files were found in %s", paths)
+	}
+
+	var anyValid bool
+	for _, f := range files {
+		// Restrict file extensions.
+		validExtension := false
+		for _, exten := range extensions {
+			if strings.HasSuffix(f, exten) {
+				validExtension = true
+				break
+			}
+		}
+
+		if validExtension {
+			anyValid = true
+			err := rs.LoadFile(f)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if !anyValid {
+		return fmt.Errorf("No RiveScript source files were found in %s", paths)
+	}
+
+	return nil
+}
+
+/*
 Stream loads RiveScript code from a text buffer.
 
 Parameters


### PR DESCRIPTION
Added a function called LoadMultipleDirectories to loading.go.  This takes a []string instead of a string, so that the user can supply more than one directory.  

I need this because for the users of my chatbot I have a stock set of rivescript files that give basic "ALICE" like responses, but there are a bunch of rivescript files that they never need to edit, so move these to a default directory.  The user can then put any of their customizations in their own directory that is specified on startup.  In my chatbot I load the customized location after the default so that it overwrites any directives in the default rivescript folder. 